### PR TITLE
Add Syringe Pump support

### DIFF
--- a/Bonsai.Harp.CF/Bonsai.Harp.CF.csproj
+++ b/Bonsai.Harp.CF/Bonsai.Harp.CF.csproj
@@ -5,7 +5,7 @@
     <Description>Bonsai Library for data acquisition and control of Champalimaud Foundation devices implementing the Harp protocol.</Description>
     <PackageTags>Bonsai Rx Harp Champalimaud Foundation Hardware</PackageTags>
     <TargetFramework>net472</TargetFramework>
-    <Version>1.7.0</Version>
+    <Version>1.7.0-preview1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Bonsai.Harp.CF/Bonsai.Harp.CF.csproj
+++ b/Bonsai.Harp.CF/Bonsai.Harp.CF.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bonsai.Core" Version="2.5.0" />
-    <PackageReference Include="Bonsai.Harp" Version="3.0.0" />
+    <PackageReference Include="Bonsai.Harp" Version="3.2.0" />
     <PackageReference Include="OpenCV.Net" Version="3.3.1" />
   </ItemGroup>
 

--- a/Bonsai.Harp.CF/SyringePumpCommand.cs
+++ b/Bonsai.Harp.CF/SyringePumpCommand.cs
@@ -17,7 +17,9 @@ namespace Bonsai.Harp.CF
         ClearDigitalOutputs,
 
         ProtocolNumberOfSteps,
-        ProtocolStepsPeriod
+        ProtocolStepsPeriod,
+        ProtocolFlowRate,
+        ProtocolVolume
     }
 
     [TypeDescriptionProvider(typeof(DeviceTypeDescriptionProvider<SyringePumpCommand>))]
@@ -44,7 +46,8 @@ namespace Bonsai.Harp.CF
                     case SyringePumpCommandType.ClearDigitalOutputs: return "Set the state of digital output 1 using the input boolean value.";
                     case SyringePumpCommandType.ProtocolNumberOfSteps: return "Set the number of steps to run in the protocol [1;65535]";
                     case SyringePumpCommandType.ProtocolStepsPeriod: return "Set the period in ms between each step on the protocol [1;65535]";
-
+                    case SyringePumpCommandType.ProtocolFlowRate: return "Set the flow rate of the protocol [0.5;2000.0]";
+                    case SyringePumpCommandType.ProtocolVolume: return "Set the volume in uL of the protocol [0.5;2000.0]";
                     default: return null;
                 }
             }
@@ -74,6 +77,12 @@ namespace Bonsai.Harp.CF
                 case SyringePumpCommandType.ProtocolStepsPeriod:
                     if (expression.Type != typeof(ushort)) { expression = Expression.Convert(expression, typeof(ushort)); }
                     return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessProtocolStepsPeriod), null, expression);
+                case SyringePumpCommandType.ProtocolFlowRate:
+                    if (expression.Type != typeof(float)) { expression = Expression.Convert(expression, typeof(float)); }
+                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessProtocolFlowRate), null, expression);
+                case SyringePumpCommandType.ProtocolVolume:
+                    if (expression.Type != typeof(float)) { expression = Expression.Convert(expression, typeof(float)); }
+                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessProtocolVolume), null, expression);
                 default:
                     throw new InvalidOperationException("Invalid selection or not supported yet.");
             }
@@ -97,10 +106,25 @@ namespace Bonsai.Harp.CF
         static HarpMessage ProcessProtocolStepsPeriod(ushort input)
         {
             if(input <= 0)
-                throw new InvalidOperationException("Invalid number of steps. Must be above 0.");
+                throw new InvalidOperationException("Invalid steps period. Must be above 0.");
 
             return HarpCommand.WriteUInt16(address: 47, input);
         }
 
+        static HarpMessage ProcessProtocolFlowRate(float input)
+        {
+            if(input < 0.5f || input > 2000.0f)
+                throw new InvalidOperationException("Invalid flow rate value. Must be greater or equal to 0.5 and less or equal than 2000.");
+
+            return HarpCommand.WriteSingle(address: 46, input);
+        }
+
+        static HarpMessage ProcessProtocolVolume(float input)
+        {
+            if(input < 0.5f || input > 2000.0f)
+                throw new InvalidOperationException("Invalid volume value. Must be greater or equal to 0.5 and less or equal than 2000.");
+
+            return HarpCommand.WriteSingle(address: 48, input);
+        }
     }
 }

--- a/Bonsai.Harp.CF/SyringePumpCommand.cs
+++ b/Bonsai.Harp.CF/SyringePumpCommand.cs
@@ -15,6 +15,9 @@ namespace Bonsai.Harp.CF
 
         SetDigitalOutputs,
         ClearDigitalOutputs,
+
+        ProtocolNumberOfSteps,
+        ProtocolStepsPeriod
     }
 
     [TypeDescriptionProvider(typeof(DeviceTypeDescriptionProvider<SyringePumpCommand>))]
@@ -39,6 +42,8 @@ namespace Bonsai.Harp.CF
                     case SyringePumpCommandType.StopProtocol: return "Stop the running protocol on the Syringe Pump";
                     case SyringePumpCommandType.SetDigitalOutputs: return "Set the state of digital output 0 using the input boolean value.";
                     case SyringePumpCommandType.ClearDigitalOutputs: return "Set the state of digital output 1 using the input boolean value.";
+                    case SyringePumpCommandType.ProtocolNumberOfSteps: return "Set the number of steps to run in the protocol [1;65535]";
+                    case SyringePumpCommandType.ProtocolStepsPeriod: return "Set the period in ms between each step on the protocol [1;65535]";
 
                     default: return null;
                 }
@@ -63,6 +68,12 @@ namespace Bonsai.Harp.CF
                 case SyringePumpCommandType.ClearDigitalOutputs:
                     if (expression.Type != typeof(byte)) { expression = Expression.Convert(expression, typeof(byte)); }
                     return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessSetDigitalOutputs), null, expression);
+                case SyringePumpCommandType.ProtocolNumberOfSteps:
+                    if (expression.Type != typeof(ushort)) { expression = Expression.Convert(expression, typeof(ushort)); }
+                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessProtocolNumberOfSteps), null, expression);
+                case SyringePumpCommandType.ProtocolStepsPeriod:
+                    if (expression.Type != typeof(ushort)) { expression = Expression.Convert(expression, typeof(ushort)); }
+                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessProtocolStepsPeriod), null, expression);
                 default:
                     throw new InvalidOperationException("Invalid selection or not supported yet.");
             }
@@ -74,5 +85,22 @@ namespace Bonsai.Harp.CF
         static HarpMessage ProcessStopProtocol() => HarpCommand.WriteByte(address: 33, 0);
         static HarpMessage ProcessSetDigitalOutputs(byte input) => HarpCommand.WriteByte(address: 39, input);
         static HarpMessage ProcessClearDigitalOutputs(byte input) => HarpCommand.WriteByte(address: 40, input);
+
+        static HarpMessage ProcessProtocolNumberOfSteps(ushort input)
+        {
+            if(input <= 0)
+                throw new InvalidOperationException("Invalid number of steps. Must be above 0.");
+
+            return HarpCommand.WriteUInt16(address: 45, input);
+        }
+
+        static HarpMessage ProcessProtocolStepsPeriod(ushort input)
+        {
+            if(input <= 0)
+                throw new InvalidOperationException("Invalid number of steps. Must be above 0.");
+
+            return HarpCommand.WriteUInt16(address: 47, input);
+        }
+
     }
 }

--- a/Bonsai.Harp.CF/SyringePumpCommand.cs
+++ b/Bonsai.Harp.CF/SyringePumpCommand.cs
@@ -7,8 +7,7 @@ namespace Bonsai.Harp.CF
 {
     public enum SyringePumpCommandType : byte
     {
-        EnableMotorDriver,
-        DisableMotorDriver,
+        SetMotorDriver,
 
         SetDirection,
 
@@ -57,8 +56,7 @@ namespace Bonsai.Harp.CF
             {
                 switch(Type)
                 {
-                    case SyringePumpCommandType.EnableMotorDriver: return "Enables the motor on the Syringe Pump";
-                    case SyringePumpCommandType.DisableMotorDriver: return "Disables the motor on the Syringe Pump";
+                    case SyringePumpCommandType.SetMotorDriver: return "Enables/disables the motor on the Syringe Pump. Expects a boolean. 'true' enables the motor, 'false' disables the motor.";
                     case SyringePumpCommandType.SetDirection: return "Sets the direction. Expects a boolean. 'true' will set the direction to FORWARD, 'false' will set the direction to REVERSE.";
                     case SyringePumpCommandType.StartProtocol: return "Start the configured protocol on the Syringe Pump";
                     case SyringePumpCommandType.StopProtocol: return "Stop the running protocol on the Syringe Pump";
@@ -82,10 +80,9 @@ namespace Bonsai.Harp.CF
         {
             switch (Type)
             {
-                case SyringePumpCommandType.EnableMotorDriver:
-                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessEnableMotorDriver), null);
-                case SyringePumpCommandType.DisableMotorDriver:
-                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessDisableMotorDriver), null);
+                case SyringePumpCommandType.SetMotorDriver:
+                    if (expression.Type != typeof(bool)) { expression = Expression.Convert(expression, typeof(bool)); }
+                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessSetMotorDriver), null, expression);
                 case SyringePumpCommandType.SetDirection:
                     if (expression.Type != typeof(bool)) { expression = Expression.Convert(expression, typeof(bool)); }
                     return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessSetDirection), null, expression);
@@ -128,8 +125,7 @@ namespace Bonsai.Harp.CF
             }
         }
 
-        static HarpMessage ProcessEnableMotorDriver() => HarpCommand.WriteByte(address: 32, 1);
-        static HarpMessage ProcessDisableMotorDriver() => HarpCommand.WriteByte(address: 32, 0);
+        static HarpMessage ProcessSetMotorDriver(bool input) => HarpCommand.WriteByte(32, (byte) (input ? 1 : 0));
         static HarpMessage ProcessSetDirection(bool input) => HarpCommand.WriteByte(35, (byte) (input ? 1 : 0));
         static HarpMessage ProcessStartProtocol() => HarpCommand.WriteByte(address: 33, 1);
         static HarpMessage ProcessStopProtocol() => HarpCommand.WriteByte(address: 33, 0);

--- a/Bonsai.Harp.CF/SyringePumpCommand.cs
+++ b/Bonsai.Harp.CF/SyringePumpCommand.cs
@@ -88,7 +88,7 @@ namespace Bonsai.Harp.CF
                 case SyringePumpCommandType.StopProtocol:
                     return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessStopProtocol), null);
                 case SyringePumpCommandType.SetDigitalOutputs:
-                    if(expression.Type != typeof(byte)) { expression = Expression.Convert(expression, typeof(byte)); }
+                    if (expression.Type != typeof(byte)) { expression = Expression.Convert(expression, typeof(byte)); }
                     return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessSetDigitalOutputs), null, expression);
                 case SyringePumpCommandType.ClearDigitalOutputs:
                     if (expression.Type != typeof(byte)) { expression = Expression.Convert(expression, typeof(byte)); }
@@ -109,7 +109,7 @@ namespace Bonsai.Harp.CF
                     if (expression.Type != typeof(float)) { expression = Expression.Convert(expression, typeof(float)); }
                     return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessProtocolVolume), null, expression);
                 case SyringePumpCommandType.ProtocolType:
-                    if(expression.Type != typeof(bool)) { expression = Expression.Convert(expression, typeof(bool)); }
+                    if (expression.Type != typeof(bool)) { expression = Expression.Convert(expression, typeof(bool)); }
                     return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessProtocolType), null, expression);
                 case SyringePumpCommandType.CalibrationValue1:
                     if (expression.Type != typeof(byte)) { expression = Expression.Convert(expression, typeof(byte)); }
@@ -131,14 +131,15 @@ namespace Bonsai.Harp.CF
         static HarpMessage ProcessMotorMicrostep(MotorMicrostep input)
         {
             bool exists = Enum.IsDefined(typeof(MotorMicrostep), input);
-            if(!exists) throw new InvalidOperationException("Invalid Mask selection. Please select an appropriate value.");
+            if (!exists)
+                throw new InvalidOperationException("Invalid Mask selection. Please select an appropriate value.");
 
             return HarpCommand.WriteByte(address: 44, (byte)input);
         }
 
         static HarpMessage ProcessProtocolNumberOfSteps(ushort input)
         {
-            if(input <= 0)
+            if (input <= 0)
                 throw new InvalidOperationException("Invalid number of steps. Must be above 0.");
 
             return HarpCommand.WriteUInt16(address: 45, input);
@@ -146,7 +147,7 @@ namespace Bonsai.Harp.CF
 
         static HarpMessage ProcessProtocolStepsPeriod(ushort input)
         {
-            if(input <= 0)
+            if (input <= 0)
                 throw new InvalidOperationException("Invalid steps period. Must be above 0.");
 
             return HarpCommand.WriteUInt16(address: 47, input);
@@ -154,7 +155,7 @@ namespace Bonsai.Harp.CF
 
         static HarpMessage ProcessProtocolFlowRate(float input)
         {
-            if(input < 0.5f || input > 2000.0f)
+            if (input < 0.5f || input > 2000.0f)
                 throw new InvalidOperationException("Invalid flow rate value. Must be greater or equal to 0.5 and less or equal than 2000.");
 
             return HarpCommand.WriteSingle(address: 46, input);
@@ -162,7 +163,7 @@ namespace Bonsai.Harp.CF
 
         static HarpMessage ProcessProtocolVolume(float input)
         {
-            if(input < 0.5f || input > 2000.0f)
+            if (input < 0.5f || input > 2000.0f)
                 throw new InvalidOperationException("Invalid volume value. Must be greater or equal to 0.5 and less or equal than 2000.");
 
             return HarpCommand.WriteSingle(address: 48, input);

--- a/Bonsai.Harp.CF/SyringePumpCommand.cs
+++ b/Bonsai.Harp.CF/SyringePumpCommand.cs
@@ -11,8 +11,7 @@ namespace Bonsai.Harp.CF
 
         SetDirection,
 
-        StartProtocol,
-        StopProtocol,
+        EnableProtocol,
 
         SetDigitalOutputs,
         ClearDigitalOutputs,
@@ -44,7 +43,7 @@ namespace Bonsai.Harp.CF
     {
         [RefreshProperties(RefreshProperties.All)]
         [Description("Specifies which command to send to the Syringe Pump device.")]
-        public SyringePumpCommandType Type { get; set; } = SyringePumpCommandType.StartProtocol;
+        public SyringePumpCommandType Type { get; set; } = SyringePumpCommandType.EnableProtocol;
 
         public MotorMicrostep Mask { get; set; } = MotorMicrostep.Full;
 
@@ -58,10 +57,9 @@ namespace Bonsai.Harp.CF
                 {
                     case SyringePumpCommandType.SetMotorDriver: return "Enables/disables the motor on the Syringe Pump. Expects a boolean. 'true' enables the motor, 'false' disables the motor.";
                     case SyringePumpCommandType.SetDirection: return "Sets the direction. Expects a boolean. 'true' will set the direction to FORWARD, 'false' will set the direction to REVERSE.";
-                    case SyringePumpCommandType.StartProtocol: return "Start the configured protocol on the Syringe Pump";
-                    case SyringePumpCommandType.StopProtocol: return "Stop the running protocol on the Syringe Pump";
-                    case SyringePumpCommandType.SetDigitalOutputs: return "Set the state of digital output 0 using the input boolean value.";
-                    case SyringePumpCommandType.ClearDigitalOutputs: return "Set the state of digital output 1 using the input boolean value.";
+                    case SyringePumpCommandType.EnableProtocol: return "Enables/disables the previously defined protocol. Expects a boolean. 'true' will start the protocol, 'false' will stop the currently running protocol.";
+                    case SyringePumpCommandType.SetDigitalOutputs: return "Set the state of digital outputs. Expects a byte where 0 will set DO0 and 1 will set DO1.";
+                    case SyringePumpCommandType.ClearDigitalOutputs: return "Clear the state of digital outputs. Expects a byte where 0 will clear DO0 and 1 will clear DO1.";
                     case SyringePumpCommandType.MotorMicrostep: return "Set the motor microstep value.";
                     case SyringePumpCommandType.ProtocolNumberOfSteps: return "Set the number of steps to run in the protocol [1;65535]";
                     case SyringePumpCommandType.ProtocolStepsPeriod: return "Set the period in ms between each step on the protocol [1;65535]";
@@ -86,10 +84,9 @@ namespace Bonsai.Harp.CF
                 case SyringePumpCommandType.SetDirection:
                     if (expression.Type != typeof(bool)) { expression = Expression.Convert(expression, typeof(bool)); }
                     return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessSetDirection), null, expression);
-                case SyringePumpCommandType.StartProtocol:
-                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessStartProtocol), null);
-                case SyringePumpCommandType.StopProtocol:
-                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessStopProtocol), null);
+                case SyringePumpCommandType.EnableProtocol:
+                    if (expression.Type != typeof(bool)) { expression = Expression.Convert(expression, typeof(bool)); }
+                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessEnableProtocol), null, expression);
                 case SyringePumpCommandType.SetDigitalOutputs:
                     if (expression.Type != typeof(byte)) { expression = Expression.Convert(expression, typeof(byte)); }
                     return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessSetDigitalOutputs), null, expression);
@@ -127,8 +124,7 @@ namespace Bonsai.Harp.CF
 
         static HarpMessage ProcessSetMotorDriver(bool input) => HarpCommand.WriteByte(32, (byte) (input ? 1 : 0));
         static HarpMessage ProcessSetDirection(bool input) => HarpCommand.WriteByte(35, (byte) (input ? 1 : 0));
-        static HarpMessage ProcessStartProtocol() => HarpCommand.WriteByte(address: 33, 1);
-        static HarpMessage ProcessStopProtocol() => HarpCommand.WriteByte(address: 33, 0);
+        static HarpMessage ProcessEnableProtocol(bool input) => HarpCommand.WriteByte(33, (byte) (input ? 1 : 0));
         static HarpMessage ProcessSetDigitalOutputs(byte input) => HarpCommand.WriteByte(address: 39, input);
         static HarpMessage ProcessClearDigitalOutputs(byte input) => HarpCommand.WriteByte(address: 40, input);
         static HarpMessage ProcessMotorMicrostep(MotorMicrostep input)

--- a/Bonsai.Harp.CF/SyringePumpCommand.cs
+++ b/Bonsai.Harp.CF/SyringePumpCommand.cs
@@ -21,6 +21,9 @@ namespace Bonsai.Harp.CF
         ProtocolFlowRate,
         ProtocolVolume,
         ProtocolType,
+
+        CalibrationValue1,
+        CalibrationValue2
     }
 
     [TypeDescriptionProvider(typeof(DeviceTypeDescriptionProvider<SyringePumpCommand>))]
@@ -50,6 +53,9 @@ namespace Bonsai.Harp.CF
                     case SyringePumpCommandType.ProtocolFlowRate: return "Set the flow rate of the protocol [0.5;2000.0]";
                     case SyringePumpCommandType.ProtocolVolume: return "Set the volume in uL of the protocol [0.5;2000.0]";
                     case SyringePumpCommandType.ProtocolType: return "Set the type of the protocol. False for step-based and True to volume-based protocol.";
+                    case SyringePumpCommandType.CalibrationValue1: return "Set the calibration value 1 for protocol use.";
+                    case SyringePumpCommandType.CalibrationValue2: return "Set the calibration value 1 for protocol use.";
+
                     default: return null;
                 }
             }
@@ -88,6 +94,12 @@ namespace Bonsai.Harp.CF
                 case SyringePumpCommandType.ProtocolType:
                     if(expression.Type != typeof(bool)) { expression = Expression.Convert(expression, typeof(bool)); }
                     return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessProtocolType), null, expression);
+                case SyringePumpCommandType.CalibrationValue1:
+                    if (expression.Type != typeof(byte)) { expression = Expression.Convert(expression, typeof(byte)); }
+                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessCalibrationValue1), null, expression);
+                case SyringePumpCommandType.CalibrationValue2:
+                    if (expression.Type != typeof(byte)) { expression = Expression.Convert(expression, typeof(byte)); }
+                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessCalibrationValue2), null, expression);
                 default:
                     throw new InvalidOperationException("Invalid selection or not supported yet.");
             }
@@ -133,5 +145,7 @@ namespace Bonsai.Harp.CF
         }
 
         static HarpMessage ProcessProtocolType(bool input) => HarpCommand.WriteByte(address: 49, (byte)(input? 1: 0));
+        static HarpMessage ProcessCalibrationValue1(byte input) => HarpCommand.WriteByte(address: 50, input);
+        static HarpMessage ProcessCalibrationValue2(byte input) => HarpCommand.WriteByte(address: 51, input);
     }
 }

--- a/Bonsai.Harp.CF/SyringePumpCommand.cs
+++ b/Bonsai.Harp.CF/SyringePumpCommand.cs
@@ -10,6 +10,8 @@ namespace Bonsai.Harp.CF
         EnableMotorDriver,
         DisableMotorDriver,
 
+        SetDirection,
+
         StartProtocol,
         StopProtocol,
 
@@ -57,6 +59,7 @@ namespace Bonsai.Harp.CF
                 {
                     case SyringePumpCommandType.EnableMotorDriver: return "Enables the motor on the Syringe Pump";
                     case SyringePumpCommandType.DisableMotorDriver: return "Disables the motor on the Syringe Pump";
+                    case SyringePumpCommandType.SetDirection: return "Sets the direction. Expects a boolean. 'true' will set the direction to FORWARD, 'false' will set the direction to REVERSE.";
                     case SyringePumpCommandType.StartProtocol: return "Start the configured protocol on the Syringe Pump";
                     case SyringePumpCommandType.StopProtocol: return "Stop the running protocol on the Syringe Pump";
                     case SyringePumpCommandType.SetDigitalOutputs: return "Set the state of digital output 0 using the input boolean value.";
@@ -83,6 +86,9 @@ namespace Bonsai.Harp.CF
                     return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessEnableMotorDriver), null);
                 case SyringePumpCommandType.DisableMotorDriver:
                     return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessDisableMotorDriver), null);
+                case SyringePumpCommandType.SetDirection:
+                    if (expression.Type != typeof(bool)) { expression = Expression.Convert(expression, typeof(bool)); }
+                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessSetDirection), null, expression);
                 case SyringePumpCommandType.StartProtocol:
                     return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessStartProtocol), null);
                 case SyringePumpCommandType.StopProtocol:
@@ -124,6 +130,7 @@ namespace Bonsai.Harp.CF
 
         static HarpMessage ProcessEnableMotorDriver() => HarpCommand.WriteByte(address: 32, 1);
         static HarpMessage ProcessDisableMotorDriver() => HarpCommand.WriteByte(address: 32, 0);
+        static HarpMessage ProcessSetDirection(bool input) => HarpCommand.WriteByte(35, (byte) (input ? 1 : 0));
         static HarpMessage ProcessStartProtocol() => HarpCommand.WriteByte(address: 33, 1);
         static HarpMessage ProcessStopProtocol() => HarpCommand.WriteByte(address: 33, 0);
         static HarpMessage ProcessSetDigitalOutputs(byte input) => HarpCommand.WriteByte(address: 39, input);

--- a/Bonsai.Harp.CF/SyringePumpCommand.cs
+++ b/Bonsai.Harp.CF/SyringePumpCommand.cs
@@ -12,6 +12,9 @@ namespace Bonsai.Harp.CF
 
         StartProtocol,
         StopProtocol,
+
+        SetDigitalOutputs,
+        ClearDigitalOutputs,
     }
 
     [TypeDescriptionProvider(typeof(DeviceTypeDescriptionProvider<SyringePumpCommand>))]
@@ -34,6 +37,8 @@ namespace Bonsai.Harp.CF
                     case SyringePumpCommandType.DisableMotorDriver: return "Disables the motor on the Syringe Pump";
                     case SyringePumpCommandType.StartProtocol: return "Start the configured protocol on the Syringe Pump";
                     case SyringePumpCommandType.StopProtocol: return "Stop the running protocol on the Syringe Pump";
+                    case SyringePumpCommandType.SetDigitalOutputs: return "Set the state of digital output 0 using the input boolean value.";
+                    case SyringePumpCommandType.ClearDigitalOutputs: return "Set the state of digital output 1 using the input boolean value.";
 
                     default: return null;
                 }
@@ -52,6 +57,12 @@ namespace Bonsai.Harp.CF
                     return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessStartProtocol), null);
                 case SyringePumpCommandType.StopProtocol:
                     return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessStopProtocol), null);
+                case SyringePumpCommandType.SetDigitalOutputs:
+                    if(expression.Type != typeof(byte)) { expression = Expression.Convert(expression, typeof(byte)); }
+                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessSetDigitalOutputs), null, expression);
+                case SyringePumpCommandType.ClearDigitalOutputs:
+                    if (expression.Type != typeof(byte)) { expression = Expression.Convert(expression, typeof(byte)); }
+                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessSetDigitalOutputs), null, expression);
                 default:
                     throw new InvalidOperationException("Invalid selection or not supported yet.");
             }
@@ -61,5 +72,7 @@ namespace Bonsai.Harp.CF
         static HarpMessage ProcessDisableMotorDriver() => HarpCommand.WriteByte(address: 32, 0);
         static HarpMessage ProcessStartProtocol() => HarpCommand.WriteByte(address: 33, 1);
         static HarpMessage ProcessStopProtocol() => HarpCommand.WriteByte(address: 33, 0);
+        static HarpMessage ProcessSetDigitalOutputs(byte input) => HarpCommand.WriteByte(address: 39, input);
+        static HarpMessage ProcessClearDigitalOutputs(byte input) => HarpCommand.WriteByte(address: 40, input);
     }
 }

--- a/Bonsai.Harp.CF/SyringePumpCommand.cs
+++ b/Bonsai.Harp.CF/SyringePumpCommand.cs
@@ -55,19 +55,19 @@ namespace Bonsai.Harp.CF
             {
                 switch(Type)
                 {
-                    case SyringePumpCommandType.SetMotorDriver: return "Enables/disables the motor on the Syringe Pump. Expects a boolean. 'true' enables the motor, 'false' disables the motor.";
-                    case SyringePumpCommandType.SetDirection: return "Sets the direction. Expects a boolean. 'true' will set the direction to FORWARD, 'false' will set the direction to REVERSE.";
-                    case SyringePumpCommandType.EnableProtocol: return "Enables/disables the previously defined protocol. Expects a boolean. 'true' will start the protocol, 'false' will stop the currently running protocol.";
-                    case SyringePumpCommandType.SetDigitalOutputs: return "Set the state of digital outputs. Expects a byte where 0 will set DO0 and 1 will set DO1.";
-                    case SyringePumpCommandType.ClearDigitalOutputs: return "Clear the state of digital outputs. Expects a byte where 0 will clear DO0 and 1 will clear DO1.";
-                    case SyringePumpCommandType.MotorMicrostep: return "Set the motor microstep value.";
-                    case SyringePumpCommandType.ProtocolNumberOfSteps: return "Set the number of steps to run in the protocol [1;65535]";
-                    case SyringePumpCommandType.ProtocolStepsPeriod: return "Set the period in ms between each step on the protocol [1;65535]";
-                    case SyringePumpCommandType.ProtocolFlowRate: return "Set the flow rate of the protocol [0.5;2000.0]";
-                    case SyringePumpCommandType.ProtocolVolume: return "Set the volume in uL of the protocol [0.5;2000.0]";
-                    case SyringePumpCommandType.ProtocolType: return "Set the type of the protocol. False for step-based and True to volume-based protocol.";
-                    case SyringePumpCommandType.CalibrationValue1: return "Set the calibration value 1 for protocol use.";
-                    case SyringePumpCommandType.CalibrationValue2: return "Set the calibration value 2 for protocol use.";
+                    case SyringePumpCommandType.SetMotorDriver: return "Enables/disables the motor on the Syringe Pump.\n\n[Input]\nExpects a boolean.\n\n'true' enables the motor\n'false' disables the motor.";
+                    case SyringePumpCommandType.SetDirection: return "Sets the direction.\n\n[Input]\nExpects a boolean.\n\n'true' will set the direction to FORWARD\n'false' will set the direction to REVERSE.";
+                    case SyringePumpCommandType.EnableProtocol: return "Enables/disables the previously defined protocol.\n\n[Input]\nExpects a boolean.\n\n'true' will start the protocol\n'false' will stop the currently running protocol.";
+                    case SyringePumpCommandType.SetDigitalOutputs: return "Set the state of digital outputs.\n\n[Input]\nExpects a byte\n\n0x01 will set DO0\n0x02 will set DO1.\n0x03 will set both DO0 and DO1.";
+                    case SyringePumpCommandType.ClearDigitalOutputs: return "Clear the state of digital outputs.\n\n[Input]\nExpects a byte\n\n0x01 will clear DO0\n0x02 will clear DO1.\n0x03 will clear both DO0 and DO1.";
+                    case SyringePumpCommandType.MotorMicrostep: return "Set the motor microstep value.\n\n[Input]\nExpects a byte or the Mask as used by the 'Create property source' option on the Node with the following possible values:\nFull = 0\nHalf = 1\nQuarter = 2\nEighth = 3\nSixteenth = 4";
+                    case SyringePumpCommandType.ProtocolNumberOfSteps: return "Set the number of steps to run in the protocol.\n\n[Input]\nExpects a UInt16 in the following range [1;65535]";
+                    case SyringePumpCommandType.ProtocolStepsPeriod: return "Set the period in ms between each step on the protocol.\n\n[Input]\nExpects a UInt16 in the following range [1;65535]";
+                    case SyringePumpCommandType.ProtocolFlowRate: return "Set the flow rate of the protocol.\n\n[Input]\nExpects a float in the following range [0.5;2000.0]";
+                    case SyringePumpCommandType.ProtocolVolume: return "Set the volume in uL of the protocol.\n\n[Input]\nExpects a float in the following range [0.5;2000.0]";
+                    case SyringePumpCommandType.ProtocolType: return "Set the type of the protocol.\n\n[Input]\nExpects a boolean.\n\n'true' for volume-based protocol\n'false' for step-based protocol.";
+                    case SyringePumpCommandType.CalibrationValue1: return "Set the calibration value 1 for protocol use.\n\n[Input]\nExpects a byte";
+                    case SyringePumpCommandType.CalibrationValue2: return "Set the calibration value 2 for protocol use.\n\n[Input]\nExpects a byte";
 
                     default: return null;
                 }
@@ -127,14 +127,7 @@ namespace Bonsai.Harp.CF
         static HarpMessage ProcessEnableProtocol(bool input) => HarpCommand.WriteByte(33, (byte) (input ? 1 : 0));
         static HarpMessage ProcessSetDigitalOutputs(byte input) => HarpCommand.WriteByte(address: 39, input);
         static HarpMessage ProcessClearDigitalOutputs(byte input) => HarpCommand.WriteByte(address: 40, input);
-        static HarpMessage ProcessMotorMicrostep(MotorMicrostep input)
-        {
-            bool exists = Enum.IsDefined(typeof(MotorMicrostep), input);
-            if (!exists)
-                throw new InvalidOperationException("Invalid Mask selection. Please select an appropriate value.");
-
-            return HarpCommand.WriteByte(address: 44, (byte)input);
-        }
+        static HarpMessage ProcessMotorMicrostep(MotorMicrostep input) => HarpCommand.WriteByte(address: 44, (byte)input);
 
         static HarpMessage ProcessProtocolNumberOfSteps(ushort input)
         {

--- a/Bonsai.Harp.CF/SyringePumpCommand.cs
+++ b/Bonsai.Harp.CF/SyringePumpCommand.cs
@@ -7,6 +7,9 @@ namespace Bonsai.Harp.CF
 {
     public enum SyringePumpCommandType : byte
     {
+        EnableMotorDriver,
+        DisableMotorDriver,
+
         StartProtocol,
         StopProtocol,
     }
@@ -27,6 +30,8 @@ namespace Bonsai.Harp.CF
             {
                 switch(Type)
                 {
+                    case SyringePumpCommandType.EnableMotorDriver: return "Enables the motor on the Syringe Pump";
+                    case SyringePumpCommandType.DisableMotorDriver: return "Disables the motor on the Syringe Pump";
                     case SyringePumpCommandType.StartProtocol: return "Start the configured protocol on the Syringe Pump";
                     case SyringePumpCommandType.StopProtocol: return "Stop the running protocol on the Syringe Pump";
 
@@ -39,6 +44,10 @@ namespace Bonsai.Harp.CF
         {
             switch (Type)
             {
+                case SyringePumpCommandType.EnableMotorDriver:
+                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessEnableMotorDriver), null);
+                case SyringePumpCommandType.DisableMotorDriver:
+                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessDisableMotorDriver), null);
                 case SyringePumpCommandType.StartProtocol:
                     return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessStartProtocol), null);
                 case SyringePumpCommandType.StopProtocol:
@@ -48,6 +57,8 @@ namespace Bonsai.Harp.CF
             }
         }
 
+        static HarpMessage ProcessEnableMotorDriver() => HarpCommand.WriteByte(address: 32, 1);
+        static HarpMessage ProcessDisableMotorDriver() => HarpCommand.WriteByte(address: 32, 0);
         static HarpMessage ProcessStartProtocol() => HarpCommand.WriteByte(address: 33, 1);
         static HarpMessage ProcessStopProtocol() => HarpCommand.WriteByte(address: 33, 0);
     }

--- a/Bonsai.Harp.CF/SyringePumpCommand.cs
+++ b/Bonsai.Harp.CF/SyringePumpCommand.cs
@@ -67,7 +67,7 @@ namespace Bonsai.Harp.CF
                     return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessSetDigitalOutputs), null, expression);
                 case SyringePumpCommandType.ClearDigitalOutputs:
                     if (expression.Type != typeof(byte)) { expression = Expression.Convert(expression, typeof(byte)); }
-                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessSetDigitalOutputs), null, expression);
+                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessClearDigitalOutputs), null, expression);
                 case SyringePumpCommandType.ProtocolNumberOfSteps:
                     if (expression.Type != typeof(ushort)) { expression = Expression.Convert(expression, typeof(ushort)); }
                     return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessProtocolNumberOfSteps), null, expression);

--- a/Bonsai.Harp.CF/SyringePumpCommand.cs
+++ b/Bonsai.Harp.CF/SyringePumpCommand.cs
@@ -120,9 +120,9 @@ namespace Bonsai.Harp.CF
             }
         }
 
-        static HarpMessage ProcessSetMotorDriver(bool input) => HarpCommand.WriteByte(32, (byte) (input ? 1 : 0));
-        static HarpMessage ProcessSetDirection(bool input) => HarpCommand.WriteByte(35, (byte) (input ? 1 : 0));
-        static HarpMessage ProcessEnableProtocol(bool input) => HarpCommand.WriteByte(33, (byte) (input ? 1 : 0));
+        static HarpMessage ProcessSetMotorDriver(bool input) => HarpCommand.WriteByte(address: 32, (byte)(input ? 1 : 0));
+        static HarpMessage ProcessSetDirection(bool input) => HarpCommand.WriteByte(address: 35, (byte)(input ? 1 : 0));
+        static HarpMessage ProcessEnableProtocol(bool input) => HarpCommand.WriteByte(address: 33, (byte)(input ? 1 : 0));
         static HarpMessage ProcessSetDigitalOutputs(byte input) => HarpCommand.WriteByte(address: 39, input);
         static HarpMessage ProcessClearDigitalOutputs(byte input) => HarpCommand.WriteByte(address: 40, input);
         static HarpMessage ProcessMotorMicrostep(MotorMicrostep input)
@@ -143,8 +143,8 @@ namespace Bonsai.Harp.CF
 
         static HarpMessage ProcessProtocolStepsPeriod(ushort input)
         {
-            if (input < 1)
-                throw new InvalidOperationException("Invalid steps period. Must be greater or equal than 1.");
+            if (input <= 0)
+                throw new InvalidOperationException("Invalid steps period. Must be greater than 0.");
 
             return HarpCommand.WriteUInt16(address: 47, input);
         }

--- a/Bonsai.Harp.CF/SyringePumpCommand.cs
+++ b/Bonsai.Harp.CF/SyringePumpCommand.cs
@@ -61,8 +61,8 @@ namespace Bonsai.Harp.CF
                     case SyringePumpCommandType.MotorMicrostep: return "Set the motor microstep value.\n\n[Input]\nExpects a byte with the following possible values:\nFull = 0\nHalf = 1\nQuarter = 2\nEighth = 3\nSixteenth = 4";
                     case SyringePumpCommandType.ProtocolNumberOfSteps: return "Set the number of steps to run in the protocol.\n\n[Input]\nExpects a UInt16 in the following range [1;65535]";
                     case SyringePumpCommandType.ProtocolStepsPeriod: return "Set the period in ms between each step on the protocol.\n\n[Input]\nExpects a UInt16 in the following range [1;65535]";
-                    case SyringePumpCommandType.ProtocolFlowRate: return "Set the flow rate of the protocol.\n\n[Input]\nExpects a float in the following range [0.5;2000.0]";
-                    case SyringePumpCommandType.ProtocolVolume: return "Set the volume in uL of the protocol.\n\n[Input]\nExpects a float in the following range [0.5;2000.0]";
+                    case SyringePumpCommandType.ProtocolFlowRate: return "Set the flow rate (in uL/s) of the protocol.\n\n[Input]\nExpects a float greater than 0.";
+                    case SyringePumpCommandType.ProtocolVolume: return "Set the volume (in uL) of the protocol.\n\n[Input]\nExpects a float greater than 0.";
                     case SyringePumpCommandType.ProtocolType: return "Set the type of the protocol.\n\n[Input]\nExpects a boolean.\n\n'true' for volume-based protocol\n'false' for step-based protocol.";
                     case SyringePumpCommandType.CalibrationValue1: return "Set the calibration value 1 for protocol use.\n\n[Input]\nExpects a byte";
                     case SyringePumpCommandType.CalibrationValue2: return "Set the calibration value 2 for protocol use.\n\n[Input]\nExpects a byte";
@@ -136,31 +136,31 @@ namespace Bonsai.Harp.CF
         static HarpMessage ProcessProtocolNumberOfSteps(ushort input)
         {
             if (input <= 0)
-                throw new InvalidOperationException("Invalid number of steps. Must be above 0.");
+                throw new InvalidOperationException("Invalid number of steps. Must be greater than 0.");
 
             return HarpCommand.WriteUInt16(address: 45, input);
         }
 
         static HarpMessage ProcessProtocolStepsPeriod(ushort input)
         {
-            if (input <= 0)
-                throw new InvalidOperationException("Invalid steps period. Must be above 0.");
+            if (input < 1)
+                throw new InvalidOperationException("Invalid steps period. Must be greater or equal than 1.");
 
             return HarpCommand.WriteUInt16(address: 47, input);
         }
 
         static HarpMessage ProcessProtocolFlowRate(float input)
         {
-            if (input < 0.5f || input > 2000.0f)
-                throw new InvalidOperationException("Invalid flow rate value. Must be greater or equal to 0.5 and less or equal than 2000.");
+            if (input <= 0)
+                throw new InvalidOperationException("Invalid flow rate value. Must be greater than 0.");
 
             return HarpCommand.WriteSingle(address: 46, input);
         }
 
         static HarpMessage ProcessProtocolVolume(float input)
         {
-            if (input < 0.5f || input > 2000.0f)
-                throw new InvalidOperationException("Invalid volume value. Must be greater or equal to 0.5 and less or equal than 2000.");
+            if (input <= 0)
+                throw new InvalidOperationException("Invalid volume value. Must be greater than 0.");
 
             return HarpCommand.WriteSingle(address: 48, input);
         }

--- a/Bonsai.Harp.CF/SyringePumpCommand.cs
+++ b/Bonsai.Harp.CF/SyringePumpCommand.cs
@@ -45,8 +45,6 @@ namespace Bonsai.Harp.CF
         [Description("Specifies which command to send to the Syringe Pump device.")]
         public SyringePumpCommandType Type { get; set; } = SyringePumpCommandType.EnableProtocol;
 
-        public MotorMicrostep Mask { get; set; } = MotorMicrostep.Full;
-
         string INamedElement.Name => $"SyringePump.{Type}";
 
         string Description
@@ -60,7 +58,7 @@ namespace Bonsai.Harp.CF
                     case SyringePumpCommandType.EnableProtocol: return "Enables/disables the previously defined protocol.\n\n[Input]\nExpects a boolean.\n\n'true' will start the protocol\n'false' will stop the currently running protocol.";
                     case SyringePumpCommandType.SetDigitalOutputs: return "Set the state of digital outputs.\n\n[Input]\nExpects a byte\n\n0x01 will set DO0\n0x02 will set DO1.\n0x03 will set both DO0 and DO1.";
                     case SyringePumpCommandType.ClearDigitalOutputs: return "Clear the state of digital outputs.\n\n[Input]\nExpects a byte\n\n0x01 will clear DO0\n0x02 will clear DO1.\n0x03 will clear both DO0 and DO1.";
-                    case SyringePumpCommandType.MotorMicrostep: return "Set the motor microstep value.\n\n[Input]\nExpects a byte or the Mask as used by the 'Create property source' option on the Node with the following possible values:\nFull = 0\nHalf = 1\nQuarter = 2\nEighth = 3\nSixteenth = 4";
+                    case SyringePumpCommandType.MotorMicrostep: return "Set the motor microstep value.\n\n[Input]\nExpects a byte with the following possible values:\nFull = 0\nHalf = 1\nQuarter = 2\nEighth = 3\nSixteenth = 4";
                     case SyringePumpCommandType.ProtocolNumberOfSteps: return "Set the number of steps to run in the protocol.\n\n[Input]\nExpects a UInt16 in the following range [1;65535]";
                     case SyringePumpCommandType.ProtocolStepsPeriod: return "Set the period in ms between each step on the protocol.\n\n[Input]\nExpects a UInt16 in the following range [1;65535]";
                     case SyringePumpCommandType.ProtocolFlowRate: return "Set the flow rate of the protocol.\n\n[Input]\nExpects a float in the following range [0.5;2000.0]";
@@ -127,7 +125,13 @@ namespace Bonsai.Harp.CF
         static HarpMessage ProcessEnableProtocol(bool input) => HarpCommand.WriteByte(33, (byte) (input ? 1 : 0));
         static HarpMessage ProcessSetDigitalOutputs(byte input) => HarpCommand.WriteByte(address: 39, input);
         static HarpMessage ProcessClearDigitalOutputs(byte input) => HarpCommand.WriteByte(address: 40, input);
-        static HarpMessage ProcessMotorMicrostep(MotorMicrostep input) => HarpCommand.WriteByte(address: 44, (byte)input);
+        static HarpMessage ProcessMotorMicrostep(MotorMicrostep input)
+        {
+            if(!Enum.IsDefined(typeof(MotorMicrostep), input))
+                throw new InvalidOperationException("Invalid MotorMicrostep value. Valid values are: \nFull = 0\nHalf = 1\nQuarter = 2\nEighth = 3\nSixteenth = 4.");
+
+            return HarpCommand.WriteByte(address: 44, (byte) input);
+        }
 
         static HarpMessage ProcessProtocolNumberOfSteps(ushort input)
         {

--- a/Bonsai.Harp.CF/SyringePumpCommand.cs
+++ b/Bonsai.Harp.CF/SyringePumpCommand.cs
@@ -1,0 +1,54 @@
+﻿using Bonsai.Expressions;
+using System;
+using System.ComponentModel;
+using System.Linq.Expressions;
+
+namespace Bonsai.Harp.CF
+{
+    public enum SyringePumpCommandType : byte
+    {
+        StartProtocol,
+        StopProtocol,
+    }
+
+    [TypeDescriptionProvider(typeof(DeviceTypeDescriptionProvider<SyringePumpCommand>))]
+    [Description("Creates standard command messages available to the Syringe Pump device")]
+    public class SyringePumpCommand : SelectBuilder, INamedElement
+    {
+        [RefreshProperties(RefreshProperties.All)]
+        [Description("Specifies which command to send to the Syringe Pump device.")]
+        public SyringePumpCommandType Type { get; set; } = SyringePumpCommandType.StartProtocol;
+
+        string INamedElement.Name => $"SyringePump.{Type}";
+
+        string Description
+        {
+            get
+            {
+                switch(Type)
+                {
+                    case SyringePumpCommandType.StartProtocol: return "Start the configured protocol on the Syringe Pump";
+                    case SyringePumpCommandType.StopProtocol: return "Stop the running protocol on the Syringe Pump";
+
+                    default: return null;
+                }
+            }
+        }
+
+        protected override Expression BuildSelector(Expression expression)
+        {
+            switch (Type)
+            {
+                case SyringePumpCommandType.StartProtocol:
+                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessStartProtocol), null);
+                case SyringePumpCommandType.StopProtocol:
+                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessStopProtocol), null);
+                default:
+                    throw new InvalidOperationException("Invalid selection or not supported yet.");
+            }
+        }
+
+        static HarpMessage ProcessStartProtocol() => HarpCommand.WriteByte(address: 33, 1);
+        static HarpMessage ProcessStopProtocol() => HarpCommand.WriteByte(address: 33, 0);
+    }
+}

--- a/Bonsai.Harp.CF/SyringePumpCommand.cs
+++ b/Bonsai.Harp.CF/SyringePumpCommand.cs
@@ -23,6 +23,7 @@ namespace Bonsai.Harp.CF
         ProtocolFlowRate,
         ProtocolVolume,
         ProtocolType,
+        ProtocolDirection,
 
         CalibrationValue1,
         CalibrationValue2
@@ -64,6 +65,7 @@ namespace Bonsai.Harp.CF
                     case SyringePumpCommandType.ProtocolFlowRate: return "Set the flow rate (in uL/s) of the protocol.\n\n[Input]\nExpects a float greater than 0.";
                     case SyringePumpCommandType.ProtocolVolume: return "Set the volume (in uL) of the protocol.\n\n[Input]\nExpects a float greater than 0.";
                     case SyringePumpCommandType.ProtocolType: return "Set the type of the protocol.\n\n[Input]\nExpects a boolean.\n\n'true' for volume-based protocol\n'false' for step-based protocol.";
+                    case SyringePumpCommandType.ProtocolDirection: return "Sets the direction that the protocol will run.\n\n[Input]\nExpects a boolean.\n\n'true' will set the direction to FORWARD\n'false' will set the direction to REVERSE.";
                     case SyringePumpCommandType.CalibrationValue1: return "Set the calibration value 1 for protocol use.\n\n[Input]\nExpects a byte";
                     case SyringePumpCommandType.CalibrationValue2: return "Set the calibration value 2 for protocol use.\n\n[Input]\nExpects a byte";
 
@@ -109,6 +111,9 @@ namespace Bonsai.Harp.CF
                 case SyringePumpCommandType.ProtocolType:
                     if (expression.Type != typeof(bool)) { expression = Expression.Convert(expression, typeof(bool)); }
                     return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessProtocolType), null, expression);
+                case SyringePumpCommandType.ProtocolDirection:
+                    if (expression.Type != typeof(bool)) { expression = Expression.Convert(expression, typeof(bool)); }
+                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessProtocolDirection), null, expression);
                 case SyringePumpCommandType.CalibrationValue1:
                     if (expression.Type != typeof(byte)) { expression = Expression.Convert(expression, typeof(byte)); }
                     return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessCalibrationValue1), null, expression);
@@ -166,6 +171,7 @@ namespace Bonsai.Harp.CF
         }
 
         static HarpMessage ProcessProtocolType(bool input) => HarpCommand.WriteByte(address: 49, (byte)(input? 1: 0));
+        static HarpMessage ProcessProtocolDirection(bool input) => HarpCommand.WriteByte(address: 55, (byte)(input? 1: 0));
         static HarpMessage ProcessCalibrationValue1(byte input) => HarpCommand.WriteByte(address: 50, input);
         static HarpMessage ProcessCalibrationValue2(byte input) => HarpCommand.WriteByte(address: 51, input);
     }

--- a/Bonsai.Harp.CF/SyringePumpCommand.cs
+++ b/Bonsai.Harp.CF/SyringePumpCommand.cs
@@ -19,7 +19,8 @@ namespace Bonsai.Harp.CF
         ProtocolNumberOfSteps,
         ProtocolStepsPeriod,
         ProtocolFlowRate,
-        ProtocolVolume
+        ProtocolVolume,
+        ProtocolType,
     }
 
     [TypeDescriptionProvider(typeof(DeviceTypeDescriptionProvider<SyringePumpCommand>))]
@@ -48,6 +49,7 @@ namespace Bonsai.Harp.CF
                     case SyringePumpCommandType.ProtocolStepsPeriod: return "Set the period in ms between each step on the protocol [1;65535]";
                     case SyringePumpCommandType.ProtocolFlowRate: return "Set the flow rate of the protocol [0.5;2000.0]";
                     case SyringePumpCommandType.ProtocolVolume: return "Set the volume in uL of the protocol [0.5;2000.0]";
+                    case SyringePumpCommandType.ProtocolType: return "Set the type of the protocol. False for step-based and True to volume-based protocol.";
                     default: return null;
                 }
             }
@@ -83,6 +85,9 @@ namespace Bonsai.Harp.CF
                 case SyringePumpCommandType.ProtocolVolume:
                     if (expression.Type != typeof(float)) { expression = Expression.Convert(expression, typeof(float)); }
                     return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessProtocolVolume), null, expression);
+                case SyringePumpCommandType.ProtocolType:
+                    if(expression.Type != typeof(bool)) { expression = Expression.Convert(expression, typeof(bool)); }
+                    return Expression.Call(typeof(SyringePumpCommand), nameof(ProcessProtocolType), null, expression);
                 default:
                     throw new InvalidOperationException("Invalid selection or not supported yet.");
             }
@@ -126,5 +131,7 @@ namespace Bonsai.Harp.CF
 
             return HarpCommand.WriteSingle(address: 48, input);
         }
+
+        static HarpMessage ProcessProtocolType(bool input) => HarpCommand.WriteByte(address: 49, (byte)(input? 1: 0));
     }
 }

--- a/Bonsai.Harp.CF/SyringePumpEvent.cs
+++ b/Bonsai.Harp.CF/SyringePumpEvent.cs
@@ -1,0 +1,77 @@
+﻿using Bonsai.Expressions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reactive.Linq;
+using TResult = System.String;
+using System.ComponentModel;
+
+namespace Bonsai.Harp.CF
+{
+    public enum SyringePumpEventType: byte
+    {
+        /* Event: STEP_STATE */
+        Step = 0,
+
+        /* Event: DIR_STATE */
+        Direction,
+    }
+
+    [TypeDescriptionProvider(typeof(DeviceTypeDescriptionProvider<WearEvent>))]
+    [Description("Filters and selects event messages reported by the Syringe Pump device.")]
+    public class SyringePumpEvent : SingleArgumentExpressionBuilder, INamedElement
+    {
+        [RefreshProperties(RefreshProperties.All)]
+        [Description("Specifies which event to select from the Syringe Pump device.")]
+        public SyringePumpEventType Type { get; set; } = SyringePumpEventType.Step;
+        
+        string INamedElement.Name => $"SyringePump.{Type}";
+
+        string Description
+        {
+            get
+            {
+                switch (Type)
+                {
+                    case SyringePumpEventType.Step: return "The state of the STEP motor controller pin.";
+                    case SyringePumpEventType.Direction: return "The state of the direction of motor's movement.";
+                    default: return null;
+                }
+            }
+        }
+
+        public override Expression Build(IEnumerable<Expression> expressions)
+        {
+            var expression = expressions.First();
+
+            switch (Type)
+            {
+                case SyringePumpEventType.Step:
+                    return Expression.Call(typeof(SyringePumpEvent), nameof(ProcessStep), null, expression);
+                case SyringePumpEventType.Direction:
+                    return Expression.Call(typeof(SyringePumpEvent), nameof(ProcessDirection), null, expression);
+                default:
+                    break;
+            }
+
+            return expression;
+        }
+
+        /************************************************************************/
+        /* Register: STEP_STATE                                                 */
+        /************************************************************************/
+        static IObservable<bool> ProcessStep(IObservable<HarpMessage> source)
+        {
+            return source.Event(address: 34).Select(input => input.GetPayloadByte() != 0);
+        }
+
+        /************************************************************************/
+        /* Register: DIR_STATE                                                  */
+        /************************************************************************/
+        static IObservable<bool> ProcessDirection(IObservable<HarpMessage> source)
+        {
+            return source.Event(address: 35).Select(input => input.GetPayloadByte() != 0);
+        }
+    }
+}

--- a/Bonsai.Harp.CF/SyringePumpEvent.cs
+++ b/Bonsai.Harp.CF/SyringePumpEvent.cs
@@ -26,7 +26,7 @@ namespace Bonsai.Harp.CF
         Input
     }
 
-    [TypeDescriptionProvider(typeof(DeviceTypeDescriptionProvider<WearEvent>))]
+    [TypeDescriptionProvider(typeof(DeviceTypeDescriptionProvider<SyringePumpEvent>))]
     [Description("Filters and selects event messages reported by the Syringe Pump device.")]
     public class SyringePumpEvent : SingleArgumentExpressionBuilder, INamedElement
     {

--- a/Bonsai.Harp.CF/SyringePumpEvent.cs
+++ b/Bonsai.Harp.CF/SyringePumpEvent.cs
@@ -4,15 +4,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reactive.Linq;
-using TResult = System.String;
 using System.ComponentModel;
 
 namespace Bonsai.Harp.CF
 {
-    public enum SyringePumpEventType: byte
+    public enum SyringePumpEventType : byte
     {
         /* Event: STEP_STATE */
-        Step = 0,
+        Step,
 
         /* Event: DIR_STATE */
         Direction,

--- a/Bonsai.Harp.CF/SyringePumpEvent.cs
+++ b/Bonsai.Harp.CF/SyringePumpEvent.cs
@@ -23,7 +23,10 @@ namespace Bonsai.Harp.CF
         SwitchReverse,
 
         /* Event: INPUT_STATE */
-        Input
+        Input,
+
+        /* Event: PROTOCOL_STATE */
+        Protocol
     }
 
     [TypeDescriptionProvider(typeof(DeviceTypeDescriptionProvider<SyringePumpEvent>))]
@@ -47,6 +50,7 @@ namespace Bonsai.Harp.CF
                     case SyringePumpEventType.SwitchForward: return "The state of the forward switch.";
                     case SyringePumpEventType.SwitchReverse: return "The state of the reverse switch.";
                     case SyringePumpEventType.Input: return "The state of the digital input 0.";
+                    case SyringePumpEventType.Protocol: return "The running state of the protocol.";
                     default: return null;
                 }
             }
@@ -68,6 +72,8 @@ namespace Bonsai.Harp.CF
                     return Expression.Call(typeof(SyringePumpEvent), nameof(ProcessSwitchReverse), null, expression);
                 case SyringePumpEventType.Input:
                     return Expression.Call(typeof(SyringePumpEvent), nameof(ProcessInput), null, expression);
+                case SyringePumpEventType.Protocol:
+                    return Expression.Call(typeof(SyringePumpEvent), nameof(ProcessProtocol), null, expression);
                 default:
                     break;
             }
@@ -98,6 +104,11 @@ namespace Bonsai.Harp.CF
         static IObservable<bool> ProcessInput(IObservable<HarpMessage> source)
         {
             return source.Event(address: 38).Select(input => input.GetPayloadByte() != 0);
+        }
+
+        static IObservable<bool> ProcessProtocol(IObservable<HarpMessage> source)
+        {
+            return source.Event(address: 54).Select(input => input.GetPayloadByte() != 0);
         }
     }
 }

--- a/Bonsai.Harp.CF/SyringePumpEvent.cs
+++ b/Bonsai.Harp.CF/SyringePumpEvent.cs
@@ -46,7 +46,7 @@ namespace Bonsai.Harp.CF
                     case SyringePumpEventType.Direction: return "The state of the direction of motor's movement.";
                     case SyringePumpEventType.SwitchForward: return "The state of the forward switch.";
                     case SyringePumpEventType.SwitchReverse: return "The state of the reverse switch.";
-                    case SyringePumpEventType.Input: return "The state of the digital input 1.";
+                    case SyringePumpEventType.Input: return "The state of the digital input 0.";
                     default: return null;
                 }
             }

--- a/Bonsai.Harp.CF/SyringePumpEvent.cs
+++ b/Bonsai.Harp.CF/SyringePumpEvent.cs
@@ -16,6 +16,12 @@ namespace Bonsai.Harp.CF
 
         /* Event: DIR_STATE */
         Direction,
+
+        /* Event: SW_FORWARD_STATE */
+        SwitchForward,
+
+        /* Event: SW_REVERSE_STATE */
+        SwitchReverse,
     }
 
     [TypeDescriptionProvider(typeof(DeviceTypeDescriptionProvider<WearEvent>))]
@@ -36,6 +42,8 @@ namespace Bonsai.Harp.CF
                 {
                     case SyringePumpEventType.Step: return "The state of the STEP motor controller pin.";
                     case SyringePumpEventType.Direction: return "The state of the direction of motor's movement.";
+                    case SyringePumpEventType.SwitchForward: return "The state of the forward switch.";
+                    case SyringePumpEventType.SwitchReverse: return "The state of the reverse switch.";
                     default: return null;
                 }
             }
@@ -51,6 +59,10 @@ namespace Bonsai.Harp.CF
                     return Expression.Call(typeof(SyringePumpEvent), nameof(ProcessStep), null, expression);
                 case SyringePumpEventType.Direction:
                     return Expression.Call(typeof(SyringePumpEvent), nameof(ProcessDirection), null, expression);
+                case SyringePumpEventType.SwitchForward:
+                    return Expression.Call(typeof(SyringePumpEvent), nameof(ProcessSwitchForward), null, expression);
+                case SyringePumpEventType.SwitchReverse:
+                    return Expression.Call(typeof(SyringePumpEvent), nameof(ProcessSwitchReverse), null, expression);
                 default:
                     break;
             }
@@ -58,20 +70,24 @@ namespace Bonsai.Harp.CF
             return expression;
         }
 
-        /************************************************************************/
-        /* Register: STEP_STATE                                                 */
-        /************************************************************************/
         static IObservable<bool> ProcessStep(IObservable<HarpMessage> source)
         {
             return source.Event(address: 34).Select(input => input.GetPayloadByte() != 0);
         }
 
-        /************************************************************************/
-        /* Register: DIR_STATE                                                  */
-        /************************************************************************/
         static IObservable<bool> ProcessDirection(IObservable<HarpMessage> source)
         {
             return source.Event(address: 35).Select(input => input.GetPayloadByte() != 0);
+        }
+
+        static IObservable<bool> ProcessSwitchForward(IObservable<HarpMessage> source)
+        {
+            return source.Event(address: 36).Select(input => input.GetPayloadByte() != 0);
+        }
+
+        static IObservable<bool> ProcessSwitchReverse(IObservable<HarpMessage> source)
+        {
+            return source.Event(address: 37).Select(input => input.GetPayloadByte() != 0);
         }
     }
 }

--- a/Bonsai.Harp.CF/SyringePumpEvent.cs
+++ b/Bonsai.Harp.CF/SyringePumpEvent.cs
@@ -22,6 +22,9 @@ namespace Bonsai.Harp.CF
 
         /* Event: SW_REVERSE_STATE */
         SwitchReverse,
+
+        /* Event: INPUT_STATE */
+        Input
     }
 
     [TypeDescriptionProvider(typeof(DeviceTypeDescriptionProvider<WearEvent>))]
@@ -44,6 +47,7 @@ namespace Bonsai.Harp.CF
                     case SyringePumpEventType.Direction: return "The state of the direction of motor's movement.";
                     case SyringePumpEventType.SwitchForward: return "The state of the forward switch.";
                     case SyringePumpEventType.SwitchReverse: return "The state of the reverse switch.";
+                    case SyringePumpEventType.Input: return "The state of the digital input 1.";
                     default: return null;
                 }
             }
@@ -63,6 +67,8 @@ namespace Bonsai.Harp.CF
                     return Expression.Call(typeof(SyringePumpEvent), nameof(ProcessSwitchForward), null, expression);
                 case SyringePumpEventType.SwitchReverse:
                     return Expression.Call(typeof(SyringePumpEvent), nameof(ProcessSwitchReverse), null, expression);
+                case SyringePumpEventType.Input:
+                    return Expression.Call(typeof(SyringePumpEvent), nameof(ProcessInput), null, expression);
                 default:
                     break;
             }
@@ -88,6 +94,11 @@ namespace Bonsai.Harp.CF
         static IObservable<bool> ProcessSwitchReverse(IObservable<HarpMessage> source)
         {
             return source.Event(address: 37).Select(input => input.GetPayloadByte() != 0);
+        }
+
+        static IObservable<bool> ProcessInput(IObservable<HarpMessage> source)
+        {
+            return source.Event(address: 38).Select(input => input.GetPayloadByte() != 0);
         }
     }
 }


### PR DESCRIPTION
Still some issues to solve, especially the Mask "workaround" that I created. 

I wanted to have some enum type validation within a Bonsai node (to simplify the use from the researcher's point of view) and that was a "solution" that worked, where the researcher can use the `Create Source Property` option for the Mask. However, this is not ideal since this mask is only used for the MotorMicrostep command.

Improvement suggestions are welcome.

Thanks!