### PR TITLE
Add support for mimic feature

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,8 +7,11 @@
     <PackageLicenseUrl>https://github.com/bonsai-rx/harp.cf/blob/main/LICENSE</PackageLicenseUrl>
     <PackageIconUrl>https://github.com/bonsai-rx/harp/raw/main/Resources/Harp.png</PackageIconUrl>
     <IncludeSymbols Condition="'$(Configuration)'=='Release'">true</IncludeSymbols>
+    <SymbolPackageFormat Condition="'$(Configuration)'=='Release'">snupkg</SymbolPackageFormat>
     <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
     <PackageOutputPath>..\bin\$(Configuration)</PackageOutputPath>
+    <RepositoryUrl>https://github.com/bonsai-rx/harp.cf.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
     <VersionSuffix>preview2</VersionSuffix>
     <Features>strict</Features>
   </PropertyGroup>


### PR DESCRIPTION
This PR adds support for the mimic feature. This enables configuring the Harp board to instantly route changes to the state of the infra-red beams or valves to specific digital outputs, without requiring a control loop through software. Mimic configuration can dynamically change at runtime.

This implementation introduces two new command types: **`MimicInfraRedBeam`** and **`MimicValve`** for controlling reporting infra-red beam and valve state, respectively.

The `Mask` property should be set to indicate which port and digital output channel pair to configure, e.g. to configure mimic of the valve state from Port0 to digital output 0 we would set `Type` to **`MimicValve`** and `Mask` to **`Port0, Digital0`**.

To disable valve mimic behavior we simply set the Mask property to the name of the Port to disable, e.g. to disable mimic of the valve state on Port0, we would set `Type` to **`MimicValve`** and `Mask` to **`Port0`**.

Fixes #4 